### PR TITLE
Help Giphy find better GIFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@
 ## Re-generate holiday files (every year)
     bundle install
     npm run holidays
+
+---
+
+If you find weird GIFs displayed for specific holidays,
+please add an alternative search term in the `fixWeirdGuesses.coffee` module.

--- a/fixWeirdGuesses.coffee
+++ b/fixWeirdGuesses.coffee
@@ -1,0 +1,3 @@
+export default
+  "Civic Holiday": "Lake Day"
+  "B.C. Day": "Rocky mountains"

--- a/gif.coffee
+++ b/gif.coffee
@@ -1,4 +1,5 @@
 import React from 'react'
+import fixWeirdGusses from '/fixWeirdGusses'
 
 url     = 'https://api.giphy.com/v1/gifs/search'
 api_key = '02c86584244447a3884c4a867d36932b'
@@ -15,7 +16,8 @@ class Gif extends React.Component
 
   componentDidMount: =>
     # giphy setup
-    q = (@props.name or 'work sad').replace(/\s+/g, '+')
+    correctedName = fixWeirdGusses[@props.name] or @props.name
+    q = (correctedName or 'work sad').replace(/\s+/g, '+')
 
     # get gifs
     res = await fetch "#{url}?#{new URLSearchParams {api_key, limit, q}}"


### PR DESCRIPTION
#### Changes
- Add `fixWeirdGuesses.coffee` file for providing alternative search terms for misleading holiday names (e.g. Civic Holiday).

Thanks @noskralc for helping me with this feature.